### PR TITLE
Add .vimrc_local.vim, update readme and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 npm-debug.log
 
 config.json
+
+_vimrc_local.vim

--- a/.vimrc_local.vim
+++ b/.vimrc_local.vim
@@ -1,0 +1,3 @@
+setlocal shiftwidth=2
+setlocal tabstop=2
+setlocal expandtab

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ In lieu of a formal styleguide, take care to maintain the existing coding
 style. Add unit tests for any new or changed functionality. Lint and test your
 code using [grunt](https://github.com/gruntjs/grunt).
 
+### Vim users
+We recommend using [this Vim script](https://code.google.com/p/lh-vim/source/browse/misc/trunk/plugin/local_vimrc.vim)
+which loads `.vimrc_local.vim` files, as well as adding the following lines to
+your `~/.vimrc`:
+
+```vim
+" Use .vimrc_local.vim instead of _vimrc_local.vim
+let g:local_vimrc = '.vimrc_local.vim'
+```
+
+_For users who don't wish to set `g:local_vimrc`, you can
+`ln -s .vimrc_local.vim _vimrc_local.vim`.  Note: `_vimrc_local.vim` is ignored
+by our `.gitignore`_
+
 ## Release History
 _(Nothing yet)_
 


### PR DESCRIPTION
So everyone's on the same page with indentation (at least, all us Vim users)
