### PR TITLE
Fixed $null error

### DIFF
--- a/lib/v1/api.js
+++ b/lib/v1/api.js
@@ -119,7 +119,7 @@
 
             Gittip.users.getPublic(username, function(data) {
                 element.setAttribute('data-gittip-readystatus', 'ready');
-                text('receiving', '$' + data.receiving);
+                text('receiving', '$' + (data.receiving || '0.00'));
                 text('username', data.username);
                 text('my-tip-button', data.my_tip == 'self' ? 'You!' : (+data.my_tip > 0 ? data.my_tip : 'Gittip'));
                 text('goal', '$' + data.goal);


### PR DESCRIPTION
There was an error that made 'null' display on the widget.
