### PR TITLE
Remove the rest of minjson

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,6 +92,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-dalek');
 
     grunt.registerTask('default', ['test', 'minify']);
-    grunt.registerTask('minify', ['uglify', 'minjson', 'htmlmin']);
+    grunt.registerTask('minify', ['uglify', 'htmlmin']);
     grunt.registerTask('test', ['jshint', 'connect', 'dalek']);
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "grunt": "~0.4.4",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-jshint": "~0.9.2",
-    "grunt-minjson": "~0.1.1",
     "grunt-contrib-htmlmin": "~0.2.0",
     "grunt-dalek": "~0.2.0",
     "dalekjs": "0.0.8",


### PR DESCRIPTION
We switched from defining widgets using JSON to using HTML in 6b0be7b2ba87e07b130b3956e5c02e1fc23b8d2b. This removes the rest of `minjson`, fixing issues discovered in #64.

Up for reviewing/merging, @rohitpaulk?
