### PR TITLE
Default to HTTPS as protocol

### DIFF
--- a/lib/v1.js
+++ b/lib/v1.js
@@ -21,7 +21,7 @@
     var Gratipay = window.Gratipay || {};
 
     // Where's our files?
-    var api = window.grtpAPI || '//grtp.co/v1/';
+    var api = window.grtpAPI || 'https://grtp.co/v1/';
 
     window._grtp = window._grtp || [];
 

--- a/lib/v1/api.js
+++ b/lib/v1/api.js
@@ -1,7 +1,7 @@
 (function(_) {
     'use strict';
 
-    var api = window.grtpAPI || '//grtp.co/v1/';
+    var api = window.grtpAPI || 'https://grtp.co/v1/';
     var gratipayURI = window.gratipayURI || 'https://gratipay.com/';
     var _grtp = window._grtp || [];
 


### PR DESCRIPTION
Fixes #99 
This PR forces the HTTPS protocol rather than HTTP, as [HTTPS is becoming the standard](https://blog.mozilla.org/security/2015/04/30/deprecating-non-secure-http/) and using relative links causes issues when using other protocols besides http and https (such as file://)
Thanks!