### PR TITLE
Use ~ before usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ In the following examples, just switch out `rummik` with your Gratipay username.
 ### Standard Widgets
 ![](https://cloud.githubusercontent.com/assets/134455/4095888/3e6d7758-2fba-11e4-935f-14e30c32ac1e.png)
 ```html
-<script data-gratipay-username="rummik"
+<script data-gratipay-username="~rummik"
   src="//grtp.co/v1.js" async></script>
 ```
 
 ![](https://cloud.githubusercontent.com/assets/134455/4095889/3fb3b5f0-2fba-11e4-8adb-250a0dc4e9cf.png)
 ```html
-<script data-gratipay-username="rummik"
+<script data-gratipay-username="~rummik"
   data-gratipay-widget="button"
   src="//grtp.co/v1.js" async></script>
 ```
 
 ![](https://cloud.githubusercontent.com/assets/134455/4095908/997bc05a-2fba-11e4-99cb-56ad9cbad392.png)
 ```html
-<script data-gratipay-username="rummik"
+<script data-gratipay-username="~rummik"
   data-gratipay-widget="giving"
   src="//grtp.co/v1.js" async></script>
 ```
@@ -73,7 +73,7 @@ widget's HTML, and the following classes:
 
 
 ```html
-<div data-gratipay-username="rummik" data-gratipay-widget="custom">
+<div data-gratipay-username="~rummik" data-gratipay-widget="custom">
   I receive <a class="gratipay-profile-link">
     <span class="gratipay-receiving">$0.00</span> / wk
   </a>


### PR DESCRIPTION
Fixes sites that use HTTPS and the script until gratipay/gratipay.com#3583 is fixed.

Recommends people to use ~ to bypass 302ing links

Related to #101 