### PR TITLE
Don't serve dotfiles anymore

### DIFF
--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -29,6 +29,10 @@ server {
         autoindex on;
         try_files $uri $uri/ =404;
 
+        location ~ /\.  { 
+                return 404; 
+        }
+
         location ~ (widgets/.*\.html|\.json)$ {
                 add_header Access-Control-Allow-Origin *;
         }


### PR DESCRIPTION
Don't serve the files starting by a dot, fixing the H1 report [#120026](https://hackerone.com/reports/120026).

Returning a 404 status code will save ourselves from reports like "Code 403 indicates that the file exists".