### PR TITLE
Use our own DH value in nginx

### DIFF
--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -10,6 +10,8 @@ server {
 
         ssl_certificate certs/grtp.co.crt;
         ssl_certificate_key certs/grtp.co.key;
+        # Introduced by https://github.com/gratipay/grtp.co/issues/144
+        ssl_dhparam dhparams.pem;
 
         return 302 $scheme://grtp.co$request_uri;
 }
@@ -22,6 +24,8 @@ server {
 
         ssl_certificate certs/grtp.co.crt;
         ssl_certificate_key certs/grtp.co.key;
+        # Introduced by https://github.com/gratipay/grtp.co/issues/144
+        ssl_dhparam dhparams.pem;
 
         root /home/grtp.co/production/www;
         index index.html;


### PR DESCRIPTION
Fixes #144.

Since nginx is reloaded automatically, it should be working without any other action from us.