### PR TITLE
Serve the resources only over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ but not generated into more readable format.
 
 Configuration options:
 - `window.grtpAPI` - Where to look for the grtp.co API
-  - defaults to `//grtp.co/v2/`
+  - defaults to `https://grtp.co/v2/`
 - `window.gratipayURI` - Where to look for Gratipay
   - defaults to `https://gratipay.com/`
 
@@ -41,7 +41,7 @@ In the following examples, just switch out `my-team` with your Gratipay Team slu
 ![](https://cloud.githubusercontent.com/assets/3729038/16357975/9584b358-3acb-11e6-821c-ece9d855dca1.png)
 ```html
 <script data-gratipay-teamslug="my-team"
-  src="//grtp.co/v2.js" async></script>
+  src="https://grtp.co/v2.js" async></script>
 ```
 
 ### Custom Widgets
@@ -65,7 +65,7 @@ widget's HTML, and the following classes:
   </a>
   on <a class="gratipay-link">Gratipay</a>.
 </div>
-<script src="//grtp.co/v2.js"></script>
+<script src="https://grtp.co/v2.js"></script>
 ```
 
 
@@ -110,7 +110,7 @@ Grunt is popular JS build systems, and there are many others, like
 Gulp for example. It should be noted that `npm` itself has some kind
 of dependency management, so you may not need Grunt at all.
 
-http://blog.keithcirkel.co.uk/why-we-should-stop-using-grunt/ 
+http://blog.keithcirkel.co.uk/why-we-should-stop-using-grunt/
 
 
 ### Release and Deployment

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -6,7 +6,6 @@ server {
 
         ssl_certificate certs/grtp.co.crt;
         ssl_certificate_key certs/grtp.co.key;
-        # Introduced by https://github.com/gratipay/grtp.co/issues/144
         ssl_dhparam dhparams.pem;
 
         return 302 https://grtp.co$request_uri;
@@ -19,7 +18,6 @@ server {
 
         ssl_certificate certs/grtp.co.crt;
         ssl_certificate_key certs/grtp.co.key;
-        # Introduced by https://github.com/gratipay/grtp.co/issues/144
         ssl_dhparam dhparams.pem;
 
         root /home/grtp.co/production/www;

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,6 +1,7 @@
 server_tokens off;
 
 server {
+        listen 80;
         listen 443 ssl;
 
         server_name www.grtp.co;
@@ -13,11 +14,6 @@ server {
         ssl_dhparam dhparams.pem;
 
         return 302 https://grtp.co$request_uri;
-}
-
-server {
-        listen 80 default;
-        return 301 https://grtp.co$request_uri;
 }
 
 server {

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -12,7 +12,7 @@ server {
         # Introduced by https://github.com/gratipay/grtp.co/issues/144
         ssl_dhparam dhparams.pem;
 
-        return 301 https://grtp.co$request_uri;
+        return 302 https://grtp.co$request_uri;
 }
 
 server {

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -4,10 +4,6 @@ server {
         listen 80;
         listen 443 ssl;
 
-        server_name www.grtp.co;
-        server_name gttp.co;
-        server_name www.gttp.co;
-
         ssl_certificate certs/grtp.co.crt;
         ssl_certificate_key certs/grtp.co.key;
         # Introduced by https://github.com/gratipay/grtp.co/issues/144

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,7 +1,6 @@
 server_tokens off;
 
 server {
-        listen 80;
         listen 443 ssl;
 
         server_name www.grtp.co;
@@ -13,11 +12,15 @@ server {
         # Introduced by https://github.com/gratipay/grtp.co/issues/144
         ssl_dhparam dhparams.pem;
 
-        return 302 $scheme://grtp.co$request_uri;
+        return 301 https://grtp.co$request_uri;
 }
 
 server {
         listen 80 default;
+        return 301 https://grtp.co$request_uri;
+}
+
+server {
         listen 443 ssl;
 
         server_name grtp.co;
@@ -33,8 +36,8 @@ server {
         autoindex on;
         try_files $uri $uri/ =404;
 
-        location ~ /\.  { 
-                return 404; 
+        location ~ /\.  {
+                return 404;
         }
 
         location ~ (widgets/.*\.html|\.json)$ {


### PR DESCRIPTION
In order to close [H1-117330](https://hackerone.com/reports/117330), redirect all HTTP requests to the HTTPS URL. 

Not 100% sure it'll be working on the first try. Let's see.