### PR TITLE
Remove direct grunt invocation from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 # `make` or `make all` will just pass through to grunt.
 # The default behavior for grunt is equivalent to `grunt test && grunt build`.
-all: node_modules
-	./node_modules/.bin/grunt
+all: node_modules test build
 
 run: node_modules
-	./node_modules/.bin/grunt connect:server:keepalive
+	npm start
 
 build: node_modules
-	./node_modules/.bin/grunt build
+	npm run build
 
 test: jstest
 
@@ -18,7 +17,7 @@ node_modules: package.json
 	@if [ -d node_modules ]; then touch node_modules; fi
 
 jstest: node_modules
-	./node_modules/.bin/grunt test
+	npm test
 
 clean:
 	rm -rf node_modules

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 grtp.co [![Builds][]][Travis]
 =======
 
-Gratipay widgets + widget API
+Gratipay Widgets + API
 
 [Builds]: https://img.shields.io/travis/gratipay/grtp.co.svg "Build Status"
 [Travis]: https://travis-ci.org/gratipay/grtp.co

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grtp.co",
-  "description": "Gratipay widgets.",
+  "description": "Gratipay Widgets + API",
   "version": "0.1.5",
   "homepage": "https://github.com/gratipay/grtp.co",
   "private": true,
@@ -26,7 +26,9 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "grunt test --verbose"
+    "build": "grunt build",
+    "start": "grunt connect:server:keepalive",
+    "test": "grunt test"
   },
   "dependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
We may switch to pure npm to keep toolchain shorter.

Using `npm run build`, because `npm build` is already
a command. http://stackoverflow.com/questions/29939697